### PR TITLE
Fix error when running ODEBase.solve._solve

### DIFF
--- a/examples/diffeq/iterator.py
+++ b/examples/diffeq/iterator.py
@@ -4,8 +4,6 @@ import jax.numpy as jnp
 
 from matplotlib import pyplot as plt
 
-plt.ion()
-
 
 def f(u, pars, t, **_):
     return 1.01 * u

--- a/examples/ising1d/ising1d.py
+++ b/examples/ising1d/ising1d.py
@@ -16,10 +16,9 @@ import netket as nk
 import netket_dynamics as nkd
 
 import matplotlib.pyplot as plt
-plt.ion()
 
 # 1D Lattice
-L = 10  # 10
+L = 10
 
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 

--- a/ode4jax/_src/ODEBase/solve.py
+++ b/ode4jax/_src/ODEBase/solve.py
@@ -20,10 +20,7 @@ from .algorithms import AbstractODEAlgorithm, perform_step
 @dispatch
 def _solve(problem: ODEProblem, alg: AbstractODEAlgorithm, *args, **kwargs):
     integrator = init(problem, alg, *args, **kwargs)
-
-    integrator = _solve(integrator)
-
-    return integrator.solution
+    return _solve(integrator)
 
 @dispatch
 def _solve(integrator: ODEIntegrator):


### PR DESCRIPTION
This fixes an error when running the time evolution:
```python
$ python3 examples/diffeq/simple.py
[...]
  File "[...]/netket_dynamics/ode4jax/_src/ODEBase/solve.py", line 26, in _solve
    return integrator.solution
AttributeError: 'ODESolution' object has no attribute 'solution'
```